### PR TITLE
Fix md-paths text color

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -503,12 +503,6 @@
   color: var(--md-primary-fg-color--light);
 }
 
-/* Paths */
-.md-path__link {
-  color: var(--md-default-fg-color--light);
-}
-
-
 /* Buttons */
 .md-button {
   background-color: var(--md-primary-fg-color);
@@ -1018,3 +1012,13 @@
   background-color: transparent;
   border-radius: 0 0 0.2rem 0.2rem;
 }
+
+/* Paths */
+.md-path__item:not(:first-child)::before {
+  background-color: var(--md-default-fg-color);
+}
+
+.md-path__link {
+  color: var(--md-default-fg-color);
+}
+


### PR DESCRIPTION
Before:
<img width="2294" height="456" alt="image" src="https://github.com/user-attachments/assets/f7388ec9-cad7-44bf-b295-859b7f6953da" />


After:
<img width="2638" height="460" alt="image" src="https://github.com/user-attachments/assets/8691d1cc-e972-4761-8228-1adc3f9c5540" />

The `anchor` part of it is already correct. No need to make any changes.