### PR TITLE
Fix permalink color

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -560,6 +560,11 @@
    UI Improvements
    ======================================== */
 
+/* Permalink symbols (¶) */
+.md-typeset .headerlink {
+  color: var(--md-default-fg-color);
+}
+
 /* Make headings bolder and ensure visibility */
 .md-typeset h1,
 .md-typeset h2,


### PR DESCRIPTION
Fix permalink color. When hovering over the header text, but not the permalink text, the color of the permalink icon is too dark and hard to see.